### PR TITLE
Fix for Issue 1. WordPress 4.7 markup change breaks new menu admin fields.

### DIFF
--- a/class-fm-menu-fields-walker-nav-menu-edit.php
+++ b/class-fm-menu-fields-walker-nav-menu-edit.php
@@ -26,7 +26,7 @@ class FM_Menu_Fields_Walker_Nav_Menu_Edit extends Walker_Nav_Menu_Edit {
 		$item_output = '';
 		parent::start_el( $item_output, $item, $depth, $args, $id );
 		$output .= preg_replace(
-			'/(?=<p[^>]+class="[^"]*field-move)/',
+			'/(?=<fieldset[^>]+class="[^"]*field-move)/',
 			apply_filters( 'fmmfd_walker_nav_menu_edit_start_el', '', $item, $depth ),
 			$item_output
 		);


### PR DESCRIPTION
Fix for accessibility change in WordPress 4.7 that broke the regex in…sertion of new admin fields in the menu options. see trac ticket 35578.

https://github.com/alleyinteractive/fieldmanager-menu-fields-demo/issues/1